### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
 RUN apt-get install -y nodejs
 
 RUN mkdir /var/www
+RUN mkdir -p /dashboard
 
 COPY . /var/www/dashboard
+
+RUN ln -s /var/www/dashboard /dashboard
 
 WORKDIR /var/www/dashboard
 


### PR DESCRIPTION
Nginix is Failing to load the static content as the static content is in Dashboards /var/www directory /var will not be share across the Containers, so static content should be put some where other than /var.
So added few steps to Create a directory and link